### PR TITLE
npm package: Point to expo's repo (this one), not nolanlawson's

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "WebSQL Database API, implemented for Node using sqlite3",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nolanlawson/node-websql.git"
+    "url": "git://github.com/expo/node-websql.git"
   },
   "bugs": {
-    "url": "https://github.com/nolanlawson/node-websql/issues"
+    "url": "https://github.com/expo/node-websql/issues"
   },
   "main": "lib/index.js",
   "browser": {


### PR DESCRIPTION
Based on fa169c167, I assume this is the repo that @expo/websql is
published from.